### PR TITLE
Bugfix for issue related to use of istat/ierr

### DIFF
--- a/metric_element_create_ver8.46.f
+++ b/metric_element_create_ver8.46.f
@@ -112,7 +112,7 @@ c
 c      write(*,*) warg1
 c      call read_wout_file(warg1,ierr)
       call read_boozer_file(warg1,ierr)
-       if (istat.ne.0) stop 22
+       if (ierr.ne.0) stop 22
        
        nfp = nfp_b
        nsd = ns_b


### PR DESCRIPTION
This is a bugfix for use of `istat` where `ierr` is the correct variable. Since `istat` is uninitialized, certain compilers will throw the error even if `ierr=0`.